### PR TITLE
記事カラム修正

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -2,6 +2,10 @@
   font-family: Verdana !important;
 }
 
+.font-oswald {
+  font-family: "Oswald" !important;
+}
+
 .swiper-container {
   width: 90%;
   height: 100%;

--- a/front-page.php
+++ b/front-page.php
@@ -40,8 +40,8 @@ Template Name: TOPページ
     <div class="hidden lg:grid grid-cols-2 lg:grid-cols-11 border-t border-gray-300 lg:border-none lg:mb-32">
       <!-- ここからNEWS -->
       <div class="grid-span-1 lg:col-start-2 lg:col-end-8 flex flex-col pl-16">
-        <div class="h-14 w-full lg:h-20 lg:w-9/12 flex justify-center items-center lg:justify-start lg:items-start border-b-2 border-gray-900 lg:border-b-8 lg:border-gray-900 mb-12">
-          <div class="lg:text-5xl lg:font-bold font-verdana">
+        <div class="h-14 w-full lg:h-20 lg:w-11/12 flex justify-center items-center lg:justify-start lg:items-start border-b-2 border-gray-900 lg:border-b-4 lg:border-gray-900 mb-10">
+          <div class="lg:text-5xl font-oswald tracking-wider">
             NEW
           </div>
         </div>

--- a/template-parts/new-article.php
+++ b/template-parts/new-article.php
@@ -13,39 +13,28 @@
       $authorimg = home_url().$imgurl[2];
     }
   ?>
-  <a href="<?php the_permalink(); ?>" class="h-96 lg:h-64 w-11/12 flex flex-col lg:flex-row mb-8">
-    <div class="lg:w-4/12 bg-cover bg-center bg-no-repeat" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
-      <div class="w-2/5 bg-white flex justify-center">
-        <div class="text-red-300 pt-2 pb-2">
-          <?php if (!is_category() && has_category()): ?>
-            <span class="cat-data">
-            <?php
-              $postcat = get_the_category();
-              echo $postcat[0]->name;
-            ?>
-            </span>
-          <?php endif; ?>
+
+  <a class="w-full flex mb-12">
+    <div class="h-56 w-1/3" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
+      <div class="w-1/2 bg-white text-xs text-center pt-2 pb-2">
+        <?php if (!is_category() && has_category()): ?>
+          <?php
+            $postcat = get_the_category();
+            echo $postcat[0]->name;
+          ?>
+        <?php endif; ?>
         </div>
-      </div>
     </div>
-    <div class="h-full flex flex-col lg:w-8/12 lg:ml-3">
-      <div class="h-1/6 flex justify-between items-center mb-2">
-        <time class="text-gray-300">
-          <?php echo get_the_date('Y/m/d'); ?>
-        </time>
+    <div class="h-56 w-2/3 pt-4 pl-8 pb-4">
+      <div class="flex justify-between mb-2">
+        <div class="text-xs text-gray-300"><?php echo get_the_date('Y/m/d'); ?></div>
         <div class="flex">
-          <div class="h-8 w-8 bg-cover bg-center bg-no-repeat"><?php echo get_avatar( $author ); ?></div>
-          <div class="text-gray-300 ml-4"><?php the_author(); ?></div>
+          <div class="h-4 w-4"><?php echo get_avatar( $author ); ?></div>
+          <div class="text-xs text-gray-300 ml-2"><?php the_author(); ?></div>
         </div>
       </div>
-      <div class="h-5/6 w-full">
-        <div class="font-verdana h-2/5 w-full text-2xl pt-2 pb-2"s>
-          <?php the_title(); ?>
-        </div>
-        <div class="font-verdana h-3/5 w-full break-words pt-2 pb-2"s>
-          <?php the_excerpt(); ?>
-        </div>
-      </div>
+      <div class="h-2/6 text-2xl mb-2"><?php the_title(); ?></div>
+      <div class="h-3/6 text-sm text-gray-300 leading-8"><?php the_excerpt(); ?></div>
     </div>
   </a>
   <?php

--- a/template-parts/ranking-article.php
+++ b/template-parts/ranking-article.php
@@ -1,6 +1,6 @@
-<div class="grid-span-2 w-full lg:col-start-8 lg:col-end-11 lg:flex lg:flex-col lg:justify-self-center pr-16">
+<div class="grid-span-2 w-full lg:col-start-8 lg:col-end-11 lg:flex lg:flex-col lg:justify-self-center pl-24">
   <div class="h-14 lg:w-9/12 flex items-center justify-center lg:justify-start border-l border-b border-gray-300 lg:border-none lg:bg-black mb-8">
-    <div class="text-2xl lg:text-4xl lg:font-light lg:text-white lg:ml-4 font-verdana">
+    <div class="text-2xl lg:text-4xl lg:font-light lg:text-white lg:ml-4 font-oswald">
       RANKING
     </div>
   </div>


### PR DESCRIPTION
## 変更内容
- 記事カラムの幅（RANKINGバナーを含む）を調整
- 記事カラムの画像ができるだけ正方形になるよう調整
- テキストカラー、ファミリ、サイズを調整
- 執筆者の画像のみ高さと幅を指定

## 懸念点
NEWとRANKINGのフォントファミリが、figma上では「Oswald」だったため変更しました。
「NEW」についてはfigmaに近くなったと思います。しかし、「RANKING」については「Verdana」のほうがfigmaに近かったかと思います。

## 参考画像
<img width="1082" alt="スクリーンショット 2021-03-13 18 12 29" src="https://user-images.githubusercontent.com/61266117/111025659-eb874080-8428-11eb-863f-281000e1b049.png">
