### PR TITLE
SP版記事カラムを調整

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -34,7 +34,7 @@
   height: 400px;
 }
 #new-toggle:checked ~ #new {
-  display: block;
+  display: grid;
 }
 
 #new-toggle:not(:checked) ~ #new {
@@ -42,7 +42,7 @@
 }
 
 #ranking-toggle:checked ~ #ranking {
-  display: block;
+  display: grid;
 }
 
 #ranking-toggle:not(:checked) ~ #ranking {

--- a/front-page.php
+++ b/front-page.php
@@ -22,7 +22,7 @@ Template Name: TOPページ
             CAFE
           </div>
         </div>
-      </div>q
+      </div>
       <div class="p-4">
         <div class="text-2xl mb-2">title</div>
         <div class="text-xs text-gray-300 mb-2">2021.03.04</div>
@@ -72,31 +72,31 @@ Template Name: TOPページ
     <!-- ここからmobileメインコンテンツ -->
     <div class="lg:hidden w-screen">
       <!-- ここからスイッチ -->
-      <div class="w-full flex border-t border-gray-300">
-        <div class="w-1/2 border-b border-gray-900 flex justify-center items-center">
-          <label class="w-full text-2xl font-light text-center pt-2 pb-2 font-verdana" for="new-toggle">NEW</label>
+      <div class="h-14 w-full flex border-t border-gray-300">
+        <div class="w-1/2 flex justify-center items-center border-b border-gray-900">
+          <label class="w-full font-oswald text-xl text-center tracking-widest py-2" for="new-toggle">NEW</label>
         </div>
-        <div class="w-1/2 border-l border-b border-gray-300 flex justify-center items-center">
-          <label class="w-full text-2xl font-light text-center pt-2 pb-2 font-verdana" for="ranking-toggle">RANKING</label>
+        <div class="w-1/2 flex justify-center items-center border-l border-b border-gray-300">
+          <label class="w-full font-oswald text-xl text-center tracking-widest py-2" for="ranking-toggle">RANKING</label>
         </div>
       </div>
       <!-- スイッチここまで -->
 
       <!-- ここから投稿 -->
-      <div class="w-full grid grid-cols-2">
-        <input type="radio" class="hidden" name="new-ranking-switch" id="new-toggle" checked="checked"></input>
+      <input type="radio" class="hidden" name="new-ranking-switch" id="new-toggle" checked="checked"></input>
+      <div class="grid grid-cols-2" id="new">
         <?php get_template_part( 'template-parts/mobile-new-article' ); //NEW投稿一覧読み込み ?>
       </div>
-      <div class="w-full grid grid-cols-2">
-        <input type="radio" class="hidden" name="new-ranking-switch" id="ranking-toggle"></input>
+      <input type="radio" class="hidden" name="new-ranking-switch" id="ranking-toggle"></input>
+      <div class="w-full grid grid-cols-2" id="ranking">
         <?php get_template_part( 'template-parts/mobile-ranking-article' ); //NEW投稿一覧読み込み ?>
       </div>
       <!-- 投稿ここまで -->
 
       <!-- ここからREADMORE -->
       <div class="lg:hidden w-full flex justify-center pt-8 pb-16">
-        <div class="w-5/12 flex justify-center border-4 border-gray-900">
-          <div class="font-extralight pt-2 pb-2">READ MORE</div>
+        <div class="w-5/12 flex justify-center border-2 border-gray-900">
+          <div class="text-sm font-extralight pt-2 pb-2">READ MORE</div>
         </div>
       </div>
       <!-- READMOREここまで -->

--- a/template-parts/mobile-new-article.php
+++ b/template-parts/mobile-new-article.php
@@ -13,26 +13,22 @@
       $authorimg = home_url().$imgurl[2];
     }
   ?>
-  <div class="h-96 w-full flex flex-col items-center p-4" id="new">
-    <div class="h-2/3 w-full bg-cover bg-center" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
-      <div class="w-3/5 flex justify-center bg-white">
-        <div class="text-xs text-red-300 pt-2 pb-2">
-          <?php if (!is_category() && has_category()): ?>
-            <span class="cat-data">
-              <?php
-                $postcat = get_the_category();
-                echo $postcat[0]->name;
-              ?>
-            </span>
-          <?php endif; ?>
-        </div>
+  <div class="w-full flex flex-col items-center px-4 pt-6">
+    <div class="h-36 w-full bg-cover bg-center" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
+      <div class="w-3/5 text-xs text-red-300 text-center py-2 bg-white">
+        <?php if (!is_category() && has_category()): ?>
+          <?php
+            $postcat = get_the_category();
+            echo $postcat[0]->name;
+          ?>
+        <?php endif; ?>
       </div>
     </div>
-    <div class="h-2/12 w-full text-xl pt-2 pb-2"><?php the_title(); ?></div>
-    <div class="h-3/12 w-full flex flex-col">
+    <div class="h-20 w-full text-sm pt-4"><?php the_title(); ?></div>
+    <div class="w-full flex flex-col">
       <div class="text-xs text-gray-300"><?php echo get_the_date('Y/m/d'); ?></div>
       <div class="w-full flex items-center">
-        <div class="w-1/6 bg-contain bg-no-repeat bg-center bg-baby"><?php echo get_avatar( $author ); ?></div>
+        <div class="h-4 w-4 bg-cover bg-no-repeat bg-center"><?php echo get_avatar( $author ); ?></div>
         <div class="text-xs text-gray-300 ml-2"><?php the_author(); ?></div>
       </div>
     </div>

--- a/template-parts/mobile-ranking-article.php
+++ b/template-parts/mobile-ranking-article.php
@@ -11,20 +11,16 @@
     if($tag_posts): foreach($tag_posts as $post): setup_postdata($post);
     $i++
   ?>
-  <a href="<?php the_permalink(); ?>" class="h-24 w-full flex mb-6">
-    <div class="h-96 w-full flex flex-col items-center p-4" id="new">
-      <div class="h-2/3 w-full bg-cover bg-center" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
-        <div class="w-1/3 bg-black flex justify-center">
-          <div class="text-xs text-white pt-2 pb-2"><?php echo $i; ?></div>
-        </div>
-      </div>
-      <div class="h-2/12 w-full text-xl pt-2 pb-2"><?php the_title(); ?></div>
-      <div class="h-3/12 w-full flex flex-col">
-        <div class="text-xs text-gray-300"><?php echo get_the_date('Y/m/d'); ?></div>
-        <div class="w-full flex items-center">
-          <div class="w-1/6 bg-contain bg-no-repeat bg-center bg-baby"><?php echo get_avatar( $author ); ?></div>
-          <div class="text-xs text-gray-300 ml-2"><?php the_author(); ?></div>
-        </div>
+  <a href="<?php the_permalink(); ?>" class="w-full flex flex-col items-center px-4 pt-6">
+    <div class="h-36 w-full bg-cover bg-center" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
+      <div class="w-3/5 text-xs text-white text=center py-4 bg-black"><?php echo $i; ?></div>
+    </div>
+    <div class="h-20 w-full text-sm pt-4"><?php the_title(); ?></div>
+    <div class="w-full flex flex-col">
+      <div class="text-xs text-gray-300"><?php echo get_the_date('Y/m/d'); ?></div>
+      <div class="w-full flex items-center">
+        <div class="h-4 w-4 bg-cover bg-no-repeat bg-center"><?php echo get_avatar( $author ); ?></div>
+        <div class="text-xs text-gray-300 ml-2"><?php the_author(); ?></div>
       </div>
     </div>
   </a>


### PR DESCRIPTION
## 変更内容
- 「NEW」「RANKING」の高さ、フォントファミリ、サイズを調整
- グリッドが崩れないよう修正
- 記事カラムの画像を正方形に近い形に調整
- タイトルを表示する要素の高さを指定
- パディング、マージンを調整

## 懸念点
確認方法により、表示結果が大きく異なるのが気になります。
具体的には、画像のようにdeveloper toolで「iPhone X」を指定し、figmaでも同じ大きさに拡大縮小して比較した場合、酷似するように調整しました。
しかし、ブラウザの幅を小さくすることで表示したSP版画面と、figmaを同様の大きさに拡大縮小して比較した場合、表示は大きく異なってしまっています。

このことから、以下のようなことが考えられます。
スマホのような小さな画面サイズには依頼通りのコーディングができていますが、iPadのようなスマホ以上PC以下の端末では想定どおりの表示にならない可能性が高いです。

対応策としては、スマホの画面サイズのみ対応とし、iPadのような大きめの画面サイズではPC版を表示させることが良いかと考えます。
いかがでしょうか？

##参考画像
<img width="521" alt="スクリーンショット 2021-03-14 3 43 32" src="https://user-images.githubusercontent.com/61266117/111041308-0387b000-847b-11eb-8395-ff08a2369bf0.png">
<img width="524" alt="スクリーンショット 2021-03-14 3 43 41" src="https://user-images.githubusercontent.com/61266117/111041313-071b3700-847b-11eb-8583-4c049266f354.png">
<img width="523" alt="スクリーンショット 2021-03-14 3 43 59" src="https://user-images.githubusercontent.com/61266117/111041316-0a162780-847b-11eb-9980-c4c4b9f15d3e.png">
<img width="522" alt="スクリーンショット 2021-03-14 3 43 49" src="https://user-images.githubusercontent.com/61266117/111041315-097d9100-847b-11eb-9798-1846eaa328ee.png">
