### PR TITLE
Web版記事カラム微修正

### DIFF
--- a/template-parts/new-article.php
+++ b/template-parts/new-article.php
@@ -15,7 +15,7 @@
   ?>
 
   <a href="<?php the_permalink(); ?>" class="w-full flex mb-12">
-    <div class="h-56 w-1/3" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
+    <div class="h-56 w-1/3 bg-cover bg-center bg-no-repeat" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
       <div class="w-1/2 bg-white text-xs text-center pt-2 pb-2">
         <?php if (!is_category() && has_category()): ?>
           <?php

--- a/template-parts/ranking-article.php
+++ b/template-parts/ranking-article.php
@@ -24,7 +24,7 @@
         <div class="text-xs text-white pt-2 pb-2"><?php echo $i; ?></div>
       </div>
     </div>
-    <div class="h-full w-2/3 text-xs break-words pl-8 font-verdana"><?php the_title(); ?></div>
+    <div class="h-full w-2/3 text-sm break-words pl-8 font-verdana"><?php the_title(); ?></div>
   </a>
   <?php endforeach; endif; wp_reset_postdata(); ?>
 </div>

--- a/template-parts/ranking-article.php
+++ b/template-parts/ranking-article.php
@@ -1,5 +1,5 @@
 <div class="grid-span-2 w-full lg:col-start-8 lg:col-end-11 lg:flex lg:flex-col lg:justify-self-center pl-24">
-  <div class="h-14 lg:w-9/12 flex items-center justify-center lg:justify-start border-l border-b border-gray-300 lg:border-none lg:bg-black mb-8">
+  <div class="h-14 w-full flex items-center justify-center lg:justify-start border-l border-b border-gray-300 lg:border-none lg:bg-black mb-8">
     <div class="text-2xl lg:text-4xl lg:font-light lg:text-white lg:ml-4 font-verdana">
       RANKING
     </div>

--- a/template-parts/ranking-article.php
+++ b/template-parts/ranking-article.php
@@ -19,12 +19,12 @@
     $i++
   ?>
   <a href="<?php the_permalink(); ?>" class="h-24 w-full flex mb-6">
-    <div class="h-full w-1/4 bg-cover bg-center bg-no-repeat" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
+    <div class="w-1/3 bg-cover bg-center bg-no-repeat" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
       <div class="w-1/3 bg-black flex justify-center">
         <div class="text-xs text-white pt-2 pb-2"><?php echo $i; ?></div>
       </div>
     </div>
-    <div class="h-full w-3/4 text-xl break-words pl-8 font-verdana"><?php the_title(); ?></div>
+    <div class="h-full w-2/3 text-xs break-words pl-8 font-verdana"><?php the_title(); ?></div>
   </a>
   <?php endforeach; endif; wp_reset_postdata(); ?>
 </div>


### PR DESCRIPTION
## 変更内容

1. NEWの記事カラムのアイキャッチ画像を、センターで表示されるように調整
2. RANKINGの画像表示を正方形に調整
3. 「RANKING」の幅を、記事カラムと同じ幅に調整

最後のコミットは微調整です。依頼にあった3つの修正点は、上から3つのコミットを指します。

## 参考画像
<img width="1050" alt="スクリーンショット 2021-03-15 5 56 34" src="https://user-images.githubusercontent.com/61266117/111083912-3e5d1700-8553-11eb-88f9-f68a3916d0e7.png">
