### PR TITLE
Sp版サイドバー実装

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -103,6 +103,16 @@ Template Name: TOPページ
     </div>
     <!-- mobileメインコンテンツここまで -->
 
+    <div class="lg:hidden">
+      <!-- SP_RANKING -->
+      <?php get_template_part( 'template-parts/mobile-ranking-article' ); //RANKING読み込み ?>
+      <!-- /SP_RANKING -->
+
+      <!-- SP_CATEGORY -->
+      <?php get_template_part( 'template-parts/side-category' ); //CATEGORY一覧読み込み ?>
+      <!-- /SP_CATEGORY -->
+    </div>
+
     <!-- ここから帯 -->
     <div class="h-480 w-screen bg-bottom bg-cover flex justify-center items-center">
       <div class="h-240 w-3/4 lg:w-1/2 bg-white bg-opacity-25 flex flex-col justify-around justify-center items-center p-4">

--- a/front-page.php
+++ b/front-page.php
@@ -64,7 +64,7 @@ Template Name: TOPページ
       <!-- NEWSここまで -->
 
       <!-- ここからRANKING -->
-        <?php get_template_part( 'template-parts/ranking-article' ); //ランキング投稿一覧読み込み ?>
+      <?php get_template_part( 'sidebar' ); //サイドバー読み込み ?>
       <!-- RANKINGここまで -->
     </div>
     <!-- PCメインコンテンツここまで -->

--- a/searchform.php
+++ b/searchform.php
@@ -1,10 +1,12 @@
-<div id="search" class="search-custom-d mb-14">
-	<form method="get" id="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+<div class="rounded-full border border-black mb-14">
+	<form method="get" class="flex justify-center" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 		<label class="hidden" for="s">
 			<?php __( '', 'default' ); ?>
 		</label>
-		<input type="text" placeholder="<?php echo esc_attr( st_get_search_form_placeholder() ); ?>" value="<?php the_search_query(); ?>" name="s" id="s" />
-		<input type="submit" value="&#xf002;" class="fa" id="searchsubmit" />
+		<div class="w-full flex">
+			<input type="submit" value="&#xf002;" class="fa w-2/3 text-right" id="searchsubmit" />
+			<input type="text" placeholder="SEARCH" value="<?php the_search_query(); ?>" name="s" id="s" />
+		</div>
 	</form>
 </div>
 <!-- /stinger --> 

--- a/searchform.php
+++ b/searchform.php
@@ -1,4 +1,4 @@
-<div id="search" class="search-custom-d">
+<div id="search" class="search-custom-d mb-14">
 	<form method="get" id="searchform" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 		<label class="hidden" for="s">
 			<?php __( '', 'default' ); ?>

--- a/sidebar.php
+++ b/sidebar.php
@@ -16,13 +16,9 @@
 		} else {
 
 	?>
-<div id="side">
-	<aside>
-
+<div class="grid-span-2 col-start-8 col-end-11 w-full flex flex-col justify-self-center pl-20">
+	<?php get_template_part( 'searchform' ); //検索バー読み込み ?>
 	<?php get_template_part( 'template-parts/ranking-article' ); //ランキング投稿一覧読み込み ?>
-
-
-	</aside>
 </div>
 <!-- /#side -->
 <?php }

--- a/sidebar.php
+++ b/sidebar.php
@@ -19,6 +19,7 @@
 <div class="grid-span-2 col-start-8 col-end-11 w-full flex flex-col justify-self-center pl-20 pr-6">
 	<?php get_template_part( 'searchform' ); //検索バー読み込み ?>
 	<?php get_template_part( 'template-parts/ranking-article' ); //ランキング投稿一覧読み込み ?>
+	<?php get_template_part( 'template-parts/side-category' ); //カテゴリリンク一覧読み込み ?>
 </div>
 <!-- /#side -->
 <?php }

--- a/sidebar.php
+++ b/sidebar.php
@@ -16,7 +16,7 @@
 		} else {
 
 	?>
-<div class="grid-span-2 col-start-8 col-end-11 w-full flex flex-col justify-self-center pl-20">
+<div class="grid-span-2 col-start-8 col-end-11 w-full flex flex-col justify-self-center pl-20 pr-6">
 	<?php get_template_part( 'searchform' ); //検索バー読み込み ?>
 	<?php get_template_part( 'template-parts/ranking-article' ); //ランキング投稿一覧読み込み ?>
 </div>

--- a/style.css
+++ b/style.css
@@ -8535,10 +8535,11 @@ nav.st5,
 	color: #333;
 	font-size: 14px;
 	border-style: none;
-	padding: 10px 25px;
+	padding: 10px 0px;
 	box-sizing: border-box;
 	background-color: transparent;
-	border-radius: 0;
+	border-top-right-radius: 9999px;
+	border-bottom-right-radius: 9999px;
 	background-color: #fff;
 }
 
@@ -8551,11 +8552,13 @@ nav.st5,
 
 input#searchsubmit {
 	margin: 0;
+	padding: 10px 10px;
 	background:#fff;
-	color: #424242;
+	color: #718096;
 	cursor: pointer;
-	padding: 0 15px;
 	border: none;
+	border-top-left-radius: 9999px;
+	border-bottom-left-radius: 9999px;
 }
 
 /*カスタム検索プラグイン*/

--- a/template-parts/mobile-ranking-article.php
+++ b/template-parts/mobile-ranking-article.php
@@ -1,9 +1,14 @@
-<?php
+<div class="px-4 mb-16">
+  <div class="text-lg font-bold border-b-4 border-black pl-2 mb-8">
+    RANKING
+  </div>
+
+  <?php
     $i = 0;
     $tag_posts = get_posts(array(
         'post_type' => 'post', // 投稿タイプ
         'tag'    => 'おすすめ', // タグをスラッグで指定する場合
-        'posts_per_page' => 10, // 表示件数
+        'posts_per_page' => 5, // 表示件数
         'orderby' => 'date', // 表示順の基準
         'order' => 'ASC' // 昇順・降順
     ));
@@ -11,17 +16,18 @@
     if($tag_posts): foreach($tag_posts as $post): setup_postdata($post);
     $i++
   ?>
-  <a href="<?php the_permalink(); ?>" class="w-full flex flex-col items-center px-4 pt-6">
-    <div class="h-36 w-full bg-cover bg-center" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
-      <div class="w-3/5 text-xs text-white text=center py-4 bg-black"><?php echo $i; ?></div>
+  <a href="<?php the_permalink(); ?>" class="h-24 w-full flex px-4 mb-6">
+    <div class="w-1/3 bg-cover bg-center" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
+      <div class="w-1/3 text-xs text-white text-center bg-black py-1"><?php echo $i; ?></div>
     </div>
-    <div class="h-20 w-full text-sm pt-4"><?php the_title(); ?></div>
-    <div class="w-full flex flex-col">
-      <div class="text-xs text-gray-300"><?php echo get_the_date('Y/m/d'); ?></div>
-      <div class="w-full flex items-center">
-        <div class="h-4 w-4 bg-cover bg-no-repeat bg-center"><?php echo get_avatar( $author ); ?></div>
-        <div class="text-xs text-gray-300 ml-2"><?php the_author(); ?></div>
+    <div class="w-2/3 flex flex-col pl-6">
+      <!-- 仮置のカテゴリ表示 -->
+      <div class="flex">
+        <div class="text-xs rounded-full border border-black p-1">category</div>
+        <div class="text-xs rounded-full border border-black p-1">category</div>
       </div>
+      <!-- /仮置のカテゴリ表示 -->
+      <div class="text-sm"><?php the_title(); ?></div>
     </div>
   </a>
   <?php endforeach; endif; wp_reset_postdata(); ?>

--- a/template-parts/ranking-article.php
+++ b/template-parts/ranking-article.php
@@ -1,5 +1,4 @@
-<div class="grid-span-2 w-full lg:col-start-8 lg:col-end-11 lg:flex lg:flex-col lg:justify-self-center pl-24">
-  <div class="h-14 lg:w-9/12 flex items-center justify-center lg:justify-start border-l border-b border-gray-300 lg:border-none lg:bg-black mb-8">
+  <div class="h-14 lg:w-full flex items-center justify-center lg:justify-start border-l border-b border-gray-300 lg:border-none lg:bg-black mb-8">
     <div class="text-2xl lg:text-4xl lg:font-light lg:text-white lg:ml-4 font-verdana">
       RANKING
     </div>
@@ -19,12 +18,11 @@
     $i++
   ?>
   <a href="<?php the_permalink(); ?>" class="h-24 w-full flex mb-6">
-    <div class="h-full w-1/4 bg-cover bg-center bg-no-repeat" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
+    <div class="h-full w-1/3 bg-cover bg-center bg-no-repeat" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);">
       <div class="w-1/3 bg-black flex justify-center">
         <div class="text-xs text-white pt-2 pb-2"><?php echo $i; ?></div>
       </div>
     </div>
-    <div class="h-full w-3/4 text-xl break-words pl-8 font-verdana"><?php the_title(); ?></div>
+    <div class="h-full w-2/3 text-sm break-words pl-8 font-verdana"><?php the_title(); ?></div>
   </a>
   <?php endforeach; endif; wp_reset_postdata(); ?>
-</div>

--- a/template-parts/ranking-article.php
+++ b/template-parts/ranking-article.php
@@ -1,7 +1,6 @@
-  <div class="h-14 lg:w-full flex items-center justify-center lg:justify-start border-l border-b border-gray-300 lg:border-none lg:bg-black mb-8">
-    <div class="text-2xl lg:text-4xl lg:font-light lg:text-white lg:ml-4 font-verdana">
-      RANKING
-    </div>
+<div class="mb-24">
+  <div class="h-12 w-full mb-8 text-3xl text-white font-verdana py-2 pl-4 bg-black">
+    RANKING
   </div>
 
   <?php
@@ -32,3 +31,4 @@
     </div>
   </a>
   <?php endforeach; endif; wp_reset_postdata(); ?>
+</div>

--- a/template-parts/ranking-article.php
+++ b/template-parts/ranking-article.php
@@ -23,6 +23,12 @@
         <div class="text-xs text-white pt-2 pb-2"><?php echo $i; ?></div>
       </div>
     </div>
-    <div class="h-full w-2/3 text-sm break-words pl-8 font-verdana"><?php the_title(); ?></div>
+    <div class="h-full w-2/3 text-sm break-words pl-8 font-verdana">
+      <div class="flex mb-1">
+        <div class="text-xs border-2 border-black rounded-full p-1">category</div>
+        <div class="text-xs border-2 border-black rounded-full p-1">category</div>
+      </div>
+      <?php the_title(); ?>
+    </div>
   </a>
   <?php endforeach; endif; wp_reset_postdata(); ?>

--- a/template-parts/side-category.php
+++ b/template-parts/side-category.php
@@ -1,35 +1,35 @@
-<div class="h-12 w-full text-3xl text-white font-verdana mb-8 py-2 pl-4 bg-black">
+<div class="lg:h-12 lg:text-3xl lg:text-white lg:bg-black lg:mx-0 text-lg font-bold border-b-4 border-black font-verdana mx-4 mb-8 py-2 pl-2">
   CATEGORY
 </div>
-<div class="flex flex-col mb-8">
-  <a href="/category/コスメ" class="text-sm text-gray-500 font-semibold mb-2">コスメ</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">イエベ</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ブルベ</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ポーチの中身</a>
-</div>
-<div class="flex flex-col mb-8">
-  <a href="/category/占い・恋愛" class="text-sm text-gray-500 font-semibold mb-2">占い・恋愛</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">占い</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">恋愛</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">心理テスト</a>
-</div>
-<div class="flex flex-col mb-8">
-  <a href="/category/ファッション" class="text-sm text-gray-500 font-semibold mb-2">ファッション</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">韓国アパレル</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">20代向け</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">30~40代向け</a>
-</div>
-<div class="flex flex-col mb-8">
-  <a href="/category/ライフスタイル" class="text-sm text-gray-500 font-semibold mb-2">ライフスタイル</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">瞑想、ヨガ</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">格安SIM</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ダイエット</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">保険</a>
-</div>
-<div class="flex flex-col mb-8">
-  <a href="/category/ライター一覧" class="text-sm text-gray-500 font-semibold mb-2">アカウント一覧</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">節約チャンネル</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">スタディオンデマンド</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ライフスタイルチャンネル</a>
-  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ダイエットチャンネル</a>
-</div>
+  <div class="flex flex-col ml-8 mb-4 lg:mb-8">
+    <a href="/category/コスメ" class="text-sm text-gray-500 font-semibold mb-2">コスメ</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">イエベ</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ブルベ</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ポーチの中身</a>
+  </div>
+  <div class="flex flex-col ml-8 mb-4 lg:mb-8">
+    <a href="/category/占い・恋愛" class="text-sm text-gray-500 font-semibold mb-2">占い・恋愛</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">占い</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">恋愛</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">心理テスト</a>
+  </div>
+  <div class="flex flex-col ml-8 mb-4 lg:mb-8">
+    <a href="/category/ファッション" class="text-sm text-gray-500 font-semibold mb-2">ファッション</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">韓国アパレル</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">20代向け</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">30~40代向け</a>
+  </div>
+  <div class="flex flex-col ml-8 mb-4 lg:mb-8">
+    <a href="/category/ライフスタイル" class="text-sm text-gray-500 font-semibold mb-2">ライフスタイル</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">瞑想、ヨガ</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">格安SIM</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ダイエット</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">保険</a>
+  </div>
+  <div class="flex flex-col ml-8 mb-4 lg:mb-8">
+    <a href="/category/ライター一覧" class="text-sm text-gray-500 font-semibold mb-2">アカウント一覧</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">節約チャンネル</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">スタディオンデマンド</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ライフスタイルチャンネル</a>
+    <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ダイエットチャンネル</a>
+  </div>

--- a/template-parts/side-category.php
+++ b/template-parts/side-category.php
@@ -1,0 +1,35 @@
+<div class="h-12 w-full text-3xl text-white font-verdana mb-8 py-2 pl-4 bg-black">
+  CATEGORY
+</div>
+<div class="flex flex-col mb-8">
+  <a href="/category/コスメ" class="text-sm text-gray-500 font-semibold mb-2">コスメ</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">イエベ</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ブルベ</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ポーチの中身</a>
+</div>
+<div class="flex flex-col mb-8">
+  <a href="/category/占い・恋愛" class="text-sm text-gray-500 font-semibold mb-2">占い・恋愛</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">占い</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">恋愛</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">心理テスト</a>
+</div>
+<div class="flex flex-col mb-8">
+  <a href="/category/ファッション" class="text-sm text-gray-500 font-semibold mb-2">ファッション</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">韓国アパレル</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">20代向け</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">30~40代向け</a>
+</div>
+<div class="flex flex-col mb-8">
+  <a href="/category/ライフスタイル" class="text-sm text-gray-500 font-semibold mb-2">ライフスタイル</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">瞑想、ヨガ</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">格安SIM</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ダイエット</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">保険</a>
+</div>
+<div class="flex flex-col mb-8">
+  <a href="/category/ライター一覧" class="text-sm text-gray-500 font-semibold mb-2">アカウント一覧</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">節約チャンネル</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">スタディオンデマンド</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ライフスタイルチャンネル</a>
+  <a href="/" class="text-sm text-gray-400 mb-2 pl-4">ダイエットチャンネル</a>
+</div>


### PR DESCRIPTION
## 実装内容
- SP版RANKINGを表示
- RANKINGの記事カラムの構成を、PC版のRANKINGと同様のものへ変更
- カテゴリー一覧を表示
- カテゴリー一覧の表示を、PC版とSP版で異なるように調整

## 備考
PC版サイドバー実装のブランチから、このブランチを切っているため、PC版サイドバー実装のコミットが表示されています。
「SP版のランキングとカテゴリー一覧を読み込み」以下のコミットが、このブランチでの作業情報です。
各コミットからご確認いただけると幸いです。よろしくお願いいたします。

## 参考画像
#### ①
![SP版サイドバー実装](https://user-images.githubusercontent.com/61266117/111127488-40f15800-85b7-11eb-8c2d-72b7a8820a6c.png)

#### ②
<img width="555" alt="スクリーンショット 2021-03-15 18 09 52" src="https://user-images.githubusercontent.com/61266117/111130432-8fecbc80-85ba-11eb-972f-5a481f271394.png">

## 相談
記事カラム内のカテゴリー表示についてです。
現状、tailwindcssのクラス名を用いて最小のテキストサイズを指定しています。
しかし、それでもfigma上のデザインより少し大きく表示されてしまいます。common.cssに新しくフォントサイズを指定しても2枚目の添付画像の赤枠のサイズが最小です。（10px未満に指定しても変化はありませんでした。）
いかがしましょうか？