### PR TITLE
記事カラムのデザイン変更

### DIFF
--- a/template-parts/mobile-new-article.php
+++ b/template-parts/mobile-new-article.php
@@ -25,9 +25,13 @@
       </div>
     </div>
     <div class="h-20 w-full text-sm pt-4"><?php the_title(); ?></div>
-    <div class="w-full flex flex-col">
+    <div class="w-full flex mb-2">
+      <div class="text-xs border-2 border-black rounded-full p-1">カテゴリー</div>
+      <div class="text-xs border-2 border-black rounded-full p-1">カテゴリー</div>
+    </div>
+    <div class="w-full flex justify-between">
       <div class="text-xs text-gray-300"><?php echo get_the_date('Y/m/d'); ?></div>
-      <div class="w-full flex items-center">
+      <div class="flex">
         <div class="h-4 w-4 bg-cover bg-no-repeat bg-center"><?php echo get_avatar( $author ); ?></div>
         <div class="text-xs text-gray-300 ml-2"><?php the_author(); ?></div>
       </div>

--- a/template-parts/new-article.php
+++ b/template-parts/new-article.php
@@ -25,16 +25,20 @@
         <?php endif; ?>
         </div>
     </div>
-    <div class="h-56 w-2/3 pt-4 pl-8 pb-4">
-      <div class="flex justify-between mb-2">
+    <div class="h-56 w-2/3 py-1 pl-8">
+      <div class="flex mb-1">
+        <div class="text-xs border-2 border-black rounded-full p-1">カテゴリー</div>
+        <div class="text-xs border-2 border-black rounded-full p-1">カテゴリー</div>
+      </div>
+      <div class="flex justify-between mb-1">
         <div class="text-xs text-gray-300"><?php echo get_the_date('Y/m/d'); ?></div>
         <div class="flex">
           <div class="h-4 w-4"><?php echo get_avatar( $author ); ?></div>
           <div class="text-xs text-gray-300 ml-2"><?php the_author(); ?></div>
         </div>
       </div>
-      <div class="h-2/6 text-2xl mb-2"><?php the_title(); ?></div>
-      <div class="h-3/6 text-sm text-gray-400 leading-8"><?php the_excerpt(); ?></div>
+      <div class="h-24 text-2xl mb-1"><?php the_title(); ?></div>
+      <div class="h-16 text-sm text-gray-400"><?php the_excerpt(); ?></div>
     </div>
   </a>
   <?php


### PR DESCRIPTION
## 変更内容
#### SP版
- カテゴリ表示を挿入
- 日時とユーザー情報の配置を変更

#### PC版
- NEWの記事カラムにカテゴリ表示を挿入
- カテゴリ挿入により崩れたタイトルの高さを調整

## 参考画像
#### SP版
![記事カラムデザイン変更](https://user-images.githubusercontent.com/61266117/111289336-6601cb80-8688-11eb-8ae5-10a444390d3b.png)

#### PC版
![PC版記事カラムデザイン変更](https://user-images.githubusercontent.com/61266117/111292323-6d76a400-868b-11eb-888a-04c6a45fbcf9.png)
