### PR TITLE
記事ページとカテゴリーページにおける、サイドバーの表示調整

### DIFF
--- a/category.php
+++ b/category.php
@@ -61,12 +61,15 @@ $has_thumbnail     = st_has_term_thumbnail();
 
 		if(trim($cat_data['listdelete']) === ''){
                      //一覧を表示する場合　?>
-                        <div class="post">
-                        <?php if(trim($cat_data['st_cattitle']) !== ''){ ?>
-                            <h1 class="entry-title"><?php echo esc_html($cat_data['st_cattitle']) ?></h1>
-                        <?php }else{ ?>
-                            <h1 class="entry-title"><?php single_cat_title(); ?></h1>
-                        <?php } ?>
+
+<div class="grid grid-cols-11">
+	<div class="col-start-2 col-end-8 pl-14">
+		<div class="post">
+			<?php if(trim($cat_data['st_cattitle']) !== ''){ ?>
+				<div class="text-4xl border-b-4 border-black entry-title"><?php echo esc_html($cat_data['st_cattitle']) ?></div>
+			<?php }else{ ?>
+				<div class="w-11/12 text-4xl border-b-4 border-black pl-2 pb-4"><?php single_cat_title(); ?></div>
+			<?php } ?>
 
 			<?php if ( is_active_sidebar( 21 ) ) { ?>
 				<?php if ( function_exists( 'dynamic_sidebar' ) && dynamic_sidebar( 21 ) ) : else : //カテゴリページ上一括ウィジェット ?>
@@ -75,9 +78,9 @@ $has_thumbnail     = st_has_term_thumbnail();
 
 			<?php if(!is_paged()){ ?>
 				<div id="nocopy" <?php st_text_copyck(); ?>>
-					<?php if ( $is_thumbnal_under && $has_thumbnail ): // サムネイル ?>
-						<?php get_template_part( 'st-category-eyecatch' ); ?>
-					<?php endif; ?>
+				<?php if ( $is_thumbnal_under && $has_thumbnail ): // サムネイル ?>
+					<?php get_template_part( 'st-category-eyecatch' ); ?>
+				<?php endif; ?>
 
 					<div class="entry-content">
 						<?php echo apply_filters('the_content',category_description()); //コンテンツを表示 ?>
@@ -85,62 +88,66 @@ $has_thumbnail     = st_has_term_thumbnail();
 				</div>
 				<?php get_template_part( 'popular-thumbnail' ); //任意のエントリ ?>
 			<?php } ?>
+		</div><!-- /post -->
 
-                        </div><!-- /post -->
-
-			<?php if( category_description() && (!is_paged()) ){ //コンテンツがある場合 ?>
-				<?php if ( isset($GLOBALS['stplus']) && $GLOBALS['stplus'] === 'yes' ) {
-					get_template_part( 'st-rank' ); //ランキング
-				} ?>
-				<?php if( trim($cat_data['snscat'] ) !== '' ):
-					get_template_part( 'sns-cat' ); //ソーシャルボタン読み込み
-				endif; ?>
-				<div class="cat-itiran" style="padding-top:20px;">
-			<?php } ?>
-
-                        		<?php get_template_part( 'itiran' ); //投稿一覧読み込み ?>
-                       			<?php get_template_part( 'st-pagenavi' ); //ページナビ読み込み ?>
-
-			<?php if( category_description() && (!is_paged()) ){ //コンテンツがある場合 ?>
-				</div>
-			<?php }else{
+		<?php if( category_description() && (!is_paged()) ){ //コンテンツがある場合 ?>
+			<?php if ( isset($GLOBALS['stplus']) && $GLOBALS['stplus'] === 'yes' ) {
 				get_template_part( 'st-rank' ); //ランキング
 			} ?>
-
-		<?php }else{ //一覧を表示しない ?>
-
-                        <div class="post">
-                        <?php if(trim($cat_data['st_cattitle']) !== ''){ ?>
-                            <h1 class="entry-title"><?php echo esc_html($cat_data['st_cattitle']) ?></h1>
-                        <?php }else{ ?>
-                            <h1 class="entry-title">「<?php single_cat_title(); ?>」 一覧</h1>
-                        <?php } ?>
-
-			<?php if ( is_active_sidebar( 21 ) ) { ?>
-				<?php if ( function_exists( 'dynamic_sidebar' ) && dynamic_sidebar( 21 ) ) : else : //カテゴリページ上一括ウィジェット ?>
-				<?php endif; ?>
-			<?php } ?>
-
-			<div id="nocopy" <?php st_text_copyck(); ?>>
-				<?php if ( $is_thumbnal_under && $has_thumbnail ): // サムネイル ?>
-					<?php get_template_part( 'st-category-eyecatch' ); ?>
-				<?php endif; ?>
-
-				<div class="entry-content">
-					<?php echo apply_filters('the_content',category_description()); //コンテンツを表示 ?>
-				</div>
-			</div>
-			<?php get_template_part( 'popular-thumbnail' ); //任意のエントリ ?>
-
-			<?php if(trim($cat_data['snscat']) !== '' && (category_description())){ //コンテンツがある場合 ?>
-				<?php if ( isset($GLOBALS['stplus']) && $GLOBALS['stplus'] === 'yes' ) {
-					get_template_part( 'st-rank' ); //ランキング
-				} ?>
-				<?php get_template_part( 'sns-cat' ); //ソーシャルボタン読み込み ?>
-			<?php } ?>
-
-                        </div><!-- /post -->
+			<?php if( trim($cat_data['snscat'] ) !== '' ):
+			get_template_part( 'sns-cat' ); //ソーシャルボタン読み込み
+			endif; ?>
+			<div class="cat-itiran" style="padding-top:20px;">
 		<?php } ?>
+
+		<?php get_template_part( 'itiran' ); //投稿一覧読み込み ?>
+		<?php get_template_part( 'st-pagenavi' ); //ページナビ読み込み ?>
+
+		<?php if( category_description() && (!is_paged()) ){ //コンテンツがある場合 ?>
+			</div>
+		<?php }else{
+			get_template_part( 'st-rank' ); //ランキング
+		} ?>
+
+			<?php }else{ //一覧を表示しない ?>
+
+				<div class="post">
+					<?php if(trim($cat_data['st_cattitle']) !== ''){ ?>
+						<h1 class="entry-title"><?php echo esc_html($cat_data['st_cattitle']) ?></h1>
+					<?php }else{ ?>
+						<h1 class="entry-title">「<?php single_cat_title(); ?>」 一覧</h1>
+					<?php } ?>
+
+					<?php if ( is_active_sidebar( 21 ) ) { ?>
+						<?php if ( function_exists( 'dynamic_sidebar' ) && dynamic_sidebar( 21 ) ) : else : //カテゴリページ上一括ウィジェット ?>
+						<?php endif; ?>
+					<?php } ?>
+
+					<div id="nocopy" <?php st_text_copyck(); ?>>
+						<?php if ( $is_thumbnal_under && $has_thumbnail ): // サムネイル ?>
+							<?php get_template_part( 'st-category-eyecatch' ); ?>
+						<?php endif; ?>
+
+						<div class="entry-content">
+							<?php echo apply_filters('the_content',category_description()); //コンテンツを表示 ?>
+						</div>
+					</div>
+					<?php get_template_part( 'popular-thumbnail' ); //任意のエントリ ?>
+
+					<?php if(trim($cat_data['snscat']) !== '' && (category_description())){ //コンテンツがある場合 ?>
+						<?php if ( isset($GLOBALS['stplus']) && $GLOBALS['stplus'] === 'yes' ) {
+							get_template_part( 'st-rank' ); //ランキング
+						} ?>
+						<?php get_template_part( 'sns-cat' ); //ソーシャルボタン読み込み ?>
+					<?php } ?>
+
+				</div><!-- /post -->
+			<?php } ?>
+	</div>
+	<div class="col-start-9 col-end-12 pl-6 pr-16">
+		<?php get_sidebar(); ?>
+	</div>
+</div>
 
 		<?php if((trim($cat_data['snscat']) !== '') && (!category_description())){ //コンテンツがない場合 ?>
 			<?php if ( isset($GLOBALS['stplus']) && $GLOBALS['stplus'] === 'yes' ) {
@@ -159,7 +166,6 @@ $has_thumbnail     = st_has_term_thumbnail();
         </main>
     </div>
     <!-- /#contentInner -->
-    <?php get_sidebar(); ?>
 </div>
 <!--/#content -->
 <?php get_footer(); ?>

--- a/front-page.php
+++ b/front-page.php
@@ -64,7 +64,9 @@ Template Name: TOPページ
       <!-- NEWSここまで -->
 
       <!-- ここからRANKING -->
-      <?php get_template_part( 'sidebar' ); //サイドバー読み込み ?>
+      <div class="col-start-8 col-end-11 w-full flex flex-col justify-self-center pl-20 pr-6">
+        <?php get_template_part( 'sidebar' ); //サイドバー読み込み ?>
+      </div>
       <!-- RANKINGここまで -->
     </div>
     <!-- PCメインコンテンツここまで -->

--- a/searchform.php
+++ b/searchform.php
@@ -3,10 +3,8 @@
 		<label class="hidden" for="s">
 			<?php __( '', 'default' ); ?>
 		</label>
-		<div class="w-full flex">
-			<input type="submit" value="&#xf002;" class="fa w-2/3 text-right" id="searchsubmit" />
-			<input type="text" placeholder="SEARCH" value="<?php the_search_query(); ?>" name="s" id="s" />
-		</div>
+		<input type="text" placeholder="&#xf002; SEARCH" value="<?php the_search_query(); ?>" name="s" class="text-center rounded-full" id="s" />
+		<input type="submit" class="hidden" id="searchsubmit" />
 	</form>
 </div>
 <!-- /stinger --> 

--- a/searchform.php
+++ b/searchform.php
@@ -1,5 +1,5 @@
 <div class="rounded-full border border-black mb-14">
-	<form method="get" class="flex justify-center" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+	<form method="get" class="h-12 flex justify-center" action="<?php echo esc_url( home_url( '/' ) ); ?>">
 		<label class="hidden" for="s">
 			<?php __( '', 'default' ); ?>
 		</label>

--- a/sidebar.php
+++ b/sidebar.php
@@ -16,11 +16,10 @@
 		} else {
 
 	?>
-<div class="grid-span-2 col-start-8 col-end-11 w-full flex flex-col justify-self-center pl-20 pr-6">
+
 	<?php get_template_part( 'searchform' ); //検索バー読み込み ?>
 	<?php get_template_part( 'template-parts/ranking-article' ); //ランキング投稿一覧読み込み ?>
 	<?php get_template_part( 'template-parts/side-category' ); //カテゴリリンク一覧読み込み ?>
-</div>
 <!-- /#side -->
 <?php }
 } ?>

--- a/single-type1.php
+++ b/single-type1.php
@@ -143,46 +143,55 @@ $st_is_ex_af = st_is_ver_ex_af();
 							</p>
 						<?php endif;    // カテゴリ表示ここまで ?>
 
-						<h1 class="entry-title"><?php if ( $st_is_ex ): st_the_title(); else: the_title(); endif;    // タイトル ?></h1>
-
-						<?php get_template_part( 'itiran-date-singular' );    // 投稿日 ?>
-					<?php else:    // ヘッダーに記事データ挿入時はhetry用に出力 ※display:none ?>
-						<div style="display:none;"><?php get_template_part( 'itiran-date-singular' );    // 投稿日 ?></div>
-					<?php endif; ?>
-
-					<?php if ( isset( $GLOBALS['stdata230'] ) && $GLOBALS['stdata230'] === 'yes' ): ?>
-						<?php get_template_part( 'sns' );    // ソーシャルボタン読み込み ?>
-					<?php endif; ?>
-
-					<div class="mainbox">
-						<div id="nocopy" <?php st_text_copyck(); ?>><!-- コピー禁止エリアここから -->
-							<?php if ( ! $show_post_info && ( trim( $GLOBALS['stdata423'] ) === '' && trim( $GLOBALS['stdata217'] ) !== '' ) ): ?>
-								<?php get_template_part( 'st-eyecatch-under' ); ?>
-							<?php endif;    // アイキャッチ画像を挿入 ?>
-
-							<?php if ( $st_is_ex_af ): get_template_part( 'st-author-top' ); endif; // ライター情報を表示する ?>
-
-							<?php if ( $show_ikkatu_widget && ! st_is_mobile() && is_active_sidebar( 23 ) ): ?>
-								<?php if ( function_exists( 'dynamic_sidebar' ) ): ?>
-									<?php dynamic_sidebar( 23 );    // PCのみ ?>
-								<?php endif; ?>
-							<?php endif; ?>
-
-							<div class="entry-content">
-								<?php st_the_content( array( 'single', 'main' ) );    // 本文 ?>
+						<div class="grid grid-row-2 grid-cols-11">
+							<div class="col-start-2 pl-4">
+								<?php get_template_part( 'itiran-date-singular' );    // 投稿日 ?>
 							</div>
-						</div><!-- コピー禁止エリアここまで -->
+							<div class="col-start-2 col-end-8">
+								<div class="text-4xl border-b-4 border-black pl-4 pb-2"><?php if ( $st_is_ex ): st_the_title(); else: the_title(); endif;    // タイトル ?></div>
 
-						<?php get_template_part( 'st-kai-page' );    // 改ページ ?>
-						<?php get_template_part( 'st-ad-on' );    // 広告 ?>
+								<?php else:    // ヘッダーに記事データ挿入時はhetry用に出力 ※display:none ?>
+									<div style="display:none;"><?php get_template_part( 'itiran-date-singular' );    // 投稿日 ?></div>
+								<?php endif; ?>
 
-						<?php if ( $show_ikkatu_widget && is_active_sidebar( 5 ) ): ?>
-							<?php if ( function_exists( 'dynamic_sidebar' ) ): ?>
-								<?php dynamic_sidebar( 5 );    // 投稿ページ下一括ウィジェット ?>
-							<?php endif; ?>
-						<?php endif; ?>
+								<?php if ( isset( $GLOBALS['stdata230'] ) && $GLOBALS['stdata230'] === 'yes' ): ?>
+									<?php get_template_part( 'sns' );    // ソーシャルボタン読み込み ?>
+								<?php endif; ?>
 
-					</div><!-- .mainboxここまで -->
+								<div class="mainbox">
+									<div id="nocopy" <?php st_text_copyck(); ?>><!-- コピー禁止エリアここから -->
+										<?php if ( ! $show_post_info && ( trim( $GLOBALS['stdata423'] ) === '' && trim( $GLOBALS['stdata217'] ) !== '' ) ): ?>
+											<?php get_template_part( 'st-eyecatch-under' ); ?>
+										<?php endif;    // アイキャッチ画像を挿入 ?>
+
+										<?php if ( $st_is_ex_af ): get_template_part( 'st-author-top' ); endif; // ライター情報を表示する ?>
+
+										<?php if ( $show_ikkatu_widget && ! st_is_mobile() && is_active_sidebar( 23 ) ): ?>
+											<?php if ( function_exists( 'dynamic_sidebar' ) ): ?>
+												<?php dynamic_sidebar( 23 );    // PCのみ ?>
+											<?php endif; ?>
+										<?php endif; ?>
+
+										<div class="entry-content">
+											<?php st_the_content( array( 'single', 'main' ) );    // 本文 ?>
+										</div>
+									</div><!-- コピー禁止エリアここまで -->
+
+									<?php get_template_part( 'st-kai-page' );    // 改ページ ?>
+									<?php get_template_part( 'st-ad-on' );    // 広告 ?>
+
+									<?php if ( $show_ikkatu_widget && is_active_sidebar( 5 ) ): ?>
+										<?php if ( function_exists( 'dynamic_sidebar' ) ): ?>
+											<?php dynamic_sidebar( 5 );    // 投稿ページ下一括ウィジェット ?>
+										<?php endif; ?>
+									<?php endif; ?>
+
+								</div><!-- .mainboxここまで -->
+							</div>
+							<div class="col-start-8 col-end-12 w-full flex flex-col justify-self-center pl-20 pr-16">
+								<?php get_sidebar(); ?>
+							</div>
+						</div>
 
 					<?php if ( isset( $GLOBALS['stplus'] ) && $GLOBALS['stplus'] === 'yes' ): ?>
 						<?php get_template_part( 'st-rank' );    // ランキング ?>
@@ -216,7 +225,6 @@ $st_is_ex_af = st_is_ver_ex_af();
 		</main>
 	</div>
 	<!-- /#contentInner -->
-	<?php get_sidebar(); ?>
 </div>
 <!--/#content -->
 <?php get_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -8535,7 +8535,9 @@ nav.st5,
 	color: #333;
 	font-size: 14px;
 	border-style: none;
+	border-radius: 9999px;
 	padding: 10px 0px;
+	margin: 0px;
 	box-sizing: border-box;
 	background-color: transparent;
 	background-color: #fff;
@@ -9952,7 +9954,6 @@ footer {
 main {
 	padding: 20px 15px;
 	margin: 0 0 20px;
-	background:#fff;
 }
 
 .post {
@@ -10808,7 +10809,6 @@ ul.wp-block-latest-posts,
 	}
 
 	main {
-		background-color: #fff;
 		padding: 20px 30px;
     	padding-right: calc(constant(safe-area-inset-right) + 10px); /* iPhoneX */
     	padding-left: calc(constant(safe-area-inset-left) + 10px); /* iPhoneX */

--- a/style.css
+++ b/style.css
@@ -8538,9 +8538,11 @@ nav.st5,
 	padding: 10px 0px;
 	box-sizing: border-box;
 	background-color: transparent;
-	border-top-right-radius: 9999px;
-	border-bottom-right-radius: 9999px;
 	background-color: #fff;
+	font-family: FontAwesome;
+	font-style: normal;
+	font-weight: normal;
+	text-decoration: inherit;
 }
 
 #searchform {
@@ -8557,8 +8559,6 @@ input#searchsubmit {
 	color: #718096;
 	cursor: pointer;
 	border: none;
-	border-top-left-radius: 9999px;
-	border-bottom-left-radius: 9999px;
 }
 
 /*カスタム検索プラグイン*/

--- a/template-parts/side-category.php
+++ b/template-parts/side-category.php
@@ -1,4 +1,4 @@
-<div class="lg:h-12 lg:text-3xl lg:text-white lg:bg-black lg:mx-0 text-lg font-bold border-b-4 border-black font-verdana mx-4 mb-8 py-2 pl-2">
+<div class="lg:h-12 lg:text-3xl lg:text-white lg:bg-black lg:mx-0 lg:pl-4 text-lg border-b-4 border-black font-verdana mx-4 mb-8 py-2 pl-2">
   CATEGORY
 </div>
   <div class="flex flex-col ml-8 mb-4 lg:mb-8">


### PR DESCRIPTION
## 変更内容
- 記事ページの構成を変更
- 記事のタイトルとサイドバーの高さを合わせる
- カテゴリーページの構成を変更
- カテゴリー名とサイドバーの高さを合わせる

## 備考
今回のタスクはサイドバーの表示だったため、それぞれのページにおいて、メインコンテンツは修正していません。
カテゴリーページでの記事カラムのデザイン修正などについては、トレロにタスク化して保留リストに入れておきます。
ご認識よろしくお願いいたします。

## 参考画像
#### 記事ページ
![記事にサイドバー](https://user-images.githubusercontent.com/61266117/111341285-b85cdf80-86bc-11eb-9eb8-9a85423fee5b.png)

#### カテゴリーページ
![カテゴリにサイドバー](https://user-images.githubusercontent.com/61266117/111341340-c6126500-86bc-11eb-88bc-00fa628d43d2.png)
