### PR TITLE
SPのnew、recommendの投稿崩れ修正

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -41,12 +41,11 @@ Template Name: TOPページ
 
       <!-- ここから投稿 -->
       <input type="radio" class="hidden" name="new-recommend-switch" id="new-toggle" checked="checked" />
-
       <div id="new">
         <?php get_template_part( 'template-parts/mobile-new-article' ); //NEW投稿一覧読み込み ?>
-        <input type="radio" class="hidden" name="new-recommend-switch" id="recommend-toggle" />
       </div>
 
+      <input type="radio" class="hidden" name="new-recommend-switch" id="recommend-toggle" />
       <div id="recommend">
         <?php get_template_part( 'template-parts/mobile-recommend-article' ); //RECOMMEND投稿一覧読み込み ?>
       </div>

--- a/template-parts/mobile-recommend-article.php
+++ b/template-parts/mobile-recommend-article.php
@@ -12,7 +12,7 @@
 ?>
 
 <a href="<?php the_permalink(); ?>" class="effect_bg  mb-6 mt-6">
-  <div class=" effect_bg  mb-6 mt-6 h-32 w-full flex">
+  <div class="h-32 w-full flex">
     <div class="h-full w-1/3 bg-cover bg-center bg-no-repeat" style="background-image: url(<?php the_post_thumbnail_url( 'large' ); ?>);"></div>
     <div class="h-full w-2/3 text-sm break-words font-verdana p-3">
       <div class="w-full flex justify-between">


### PR DESCRIPTION
## 変更内容
- NEWを表示している状態で、RECOMMENDも表示されてしまっているのを修正
- RECOMMENDのボックスシャドーを修正

## NEWの投稿表示に関する画像
#### 修正前
<img width="215" alt="スクリーンショット 2021-03-24 16 35 35" src="https://user-images.githubusercontent.com/61266117/112273022-37a37200-8cc0-11eb-89c0-4fb8fdc34a3f.png">

#### 修正後
<img width="229" alt="スクリーンショット 2021-03-24 16 37 18" src="https://user-images.githubusercontent.com/61266117/112273418-abde1580-8cc0-11eb-9435-d0976791f573.png">


## ボックスシャドーに関する画像

#### 修正前
<img width="251" alt="スクリーンショット 2021-03-24 16 40 34" src="https://user-images.githubusercontent.com/61266117/112273095-4d189c00-8cc0-11eb-8fa4-e2444a38b295.png">


#### 修正後
<img width="236" alt="スクリーンショット 2021-03-24 16 40 02" src="https://user-images.githubusercontent.com/61266117/112273647-e942a300-8cc0-11eb-8c11-a956b7f9c8ce.png">
