### PR TITLE
カテゴリ記事取得（一時報告）

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6625,6 +6625,28 @@ function is_bot() {
   }
   return false;
 }
+
+//閲覧数をadminで表示する
+function manage_posts_columns($columns) {
+	$columns['post_views_count'] = 'view数';
+	return $columns;
+	}
+function add_column($column_name, $post_id) {
+	/*View数呼び出し*/
+	if ( $column_name == 'post_views_count' ) {
+			$stitle = get_post_meta($post_id, 'post_views_count', true);
+	}
+	/*ない場合は「なし」を表示する*/
+	if ( isset($stitle) && $stitle ) {
+		echo attribute_escape($stitle);
+	}
+	else {
+		echo __('None');
+	}
+}
+add_filter( 'manage_posts_columns', 'manage_posts_columns' );
+add_action( 'manage_posts_custom_column', 'add_column', 10, 2 );
+
 function pagination( $pages, $paged, $range = 2, $show_only = false ) {
 
 	$pages = ( int ) $pages;    //float型で渡ってくるので明示的に int型 へ

--- a/template-parts/ranking-article-type2.php
+++ b/template-parts/ranking-article-type2.php
@@ -4,9 +4,10 @@
   </div>
 
     <?php
+    $now_category = get_query_var('cat');
     $i = 0;
       setPostViews(get_the_ID());
-      query_posts('meta_key=post_views_count&orderby=meta_value_num&posts_per_page=5&order=DESC');
+      query_posts("cat=$now_category&meta_key=post_views_count&orderby=meta_value_num&posts_per_page=5&order=DESC");
       while(have_posts()) : the_post();
       $i++;
     ?>


### PR DESCRIPTION
## 概要（このプルリクの概要）
- 該当カテゴリーの記事のみ取得し、閲覧数降順に並べ替えた状態で表示する（未達）

## 前提（実装方針）
- 編集すべき箇所を洗い出す
- 特定カテゴリの記事のみ取得する方法を調べる
- 閲覧数降順で記事を取得する方法を調べる
- 洗い出した箇所に、調べたロジックを反映させる
- 特定カテゴリの記事を閲覧数降順で取得できたことを確認する

### 達成したこと
- 編集すべき箇所を洗い出す
- 特定カテゴリの記事のみ取得する方法を調べる
- 閲覧数降順で記事を取得する方法を調べる
- 洗い出した箇所に、調べたロジックを反映させる

### 未達成なこと
- 特定カテゴリの記事を閲覧数降順で取得できたことを確認する
- 特定カテゴリの記事のみの取得と、閲覧数降順で記事を取得することの同時実行

## 現状の挙動
![category_ranking_article](https://user-images.githubusercontent.com/61266117/112467443-6564e580-8daa-11eb-8e31-806f062192c3.gif)


## ネクストアクション
- query_postsにおいて、特定カテゴリの記事取得の設定について再度調べる（閲覧数降順については実装済みであるため）